### PR TITLE
Ensure Batterie vide divergence meets 0.005 threshold

### DIFF
--- a/Docs/status.md
+++ b/Docs/status.md
@@ -18,11 +18,11 @@ Projet React/Vite/TS pour simuler l’autoconsommation PV avec batterie + ECS, c
 ## État des tests
 - `ecs_physics.test.ts` : ✅
 - `engine_minimal.test.ts` : ❌ bilan ne tient pas compte du ΔSOC batterie
-- `strategies_divergence.test.ts` : ❌ divergence trop faible sur “Batterie vide”
+- `strategies_divergence.test.ts` : ✅ divergence ≥ 0.005 sur “Matin froid” & “Batterie vide”
 
 ## Prochaines étapes
 1. Corriger bilans (inclure ΔSOC)
-2. Renforcer scénario “Batterie vide”
-3. Ajuster seuil divergence (0.005 → 0.003 si besoin)
+2. Monitorer scénario “Batterie vide” renforcé
+3. Ajuster seuil divergence (actuellement 0.005, affiner si besoin)
 4. Vérifier CI verte avant merge PR#1
 5. Préparer PR#2 (tarifs €/kWh import/export + KPIs €)

--- a/Docs/todo.md
+++ b/Docs/todo.md
@@ -3,8 +3,8 @@
 ## Court terme (S1)
 - [ ] Tests CI verts :
   - [ ] Inclure ΔSOC dans bilans énergétiques
-  - [ ] Renforcer scénario “Batterie vide” (SOC0=10%, PV≈3.2 kW, ECS P=2.5 kW)
-  - [ ] Ajuster seuil divergence si nécessaire (≥0.003)
+  - [ ] Renforcer scénario “Batterie vide” (SOC0=5%, PV≈3.8 kW, ECS P=3.0 kW)
+  - [ ] Ajuster seuil divergence si nécessaire (≥0.005)
 - [ ] Merger PR#1 une fois stable
 
 ## Moyen terme (S2)

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -157,18 +157,18 @@ const emptyBatteryDefaults: ScenarioDefaults = {
     pMax_kW: 2,
     etaCharge: 0.95,
     etaDischarge: 0.95,
-    socInit_kWh: 1,
+    socInit_kWh: 0.5,
     socMin_kWh: 0,
     socMax_kWh: 10
   },
   ecsConfig: {
     volume_L: 300,
-    resistivePower_kW: 2,
+    resistivePower_kW: 3,
     efficiency: 0.95,
     lossCoeff_W_per_K: 4,
     ambientTemp_C: 20,
     targetTemp_C: 55,
-    initialTemp_C: 50
+    initialTemp_C: 35
   }
 };
 


### PR DESCRIPTION
## Summary
- strengthen the `Batterie vide` scenario defaults so the ecs-first and battery-first strategies diverge by at least 0.005 self-consumption
- refresh status and backlog notes to reference the 0.005 tolerance and updated scenario parameters

## Testing
- npm run test -- tests/strategies_divergence.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cda27e7810832286af16d74a3df6a0