### PR TITLE
feat: add tariff configuration and euro KPIs

### DIFF
--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -1,4 +1,5 @@
 import { ScenarioConfig, ScenarioDefaults, ScenarioPreset, ScenarioSeries } from './types';
+import { cloneTariffs, defaultTariffs } from './tariffs';
 
 export enum PresetId {
   EteEnsoleille = 'ete',
@@ -88,7 +89,8 @@ const makeSeries = (dt_s: number, pv: number[], load: number[]): ScenarioSeries 
 
 const cloneDefaults = (defaults: ScenarioDefaults): ScenarioDefaults => ({
   batteryConfig: { ...defaults.batteryConfig },
-  ecsConfig: { ...defaults.ecsConfig }
+  ecsConfig: { ...defaults.ecsConfig },
+  tariffs: cloneTariffs(defaults.tariffs)
 });
 
 const summerDefaults: ScenarioDefaults = {
@@ -109,7 +111,8 @@ const summerDefaults: ScenarioDefaults = {
     ambientTemp_C: 20,
     targetTemp_C: 55,
     initialTemp_C: 45
-  }
+  },
+  tariffs: cloneTariffs(defaultTariffs)
 };
 
 const winterDefaults: ScenarioDefaults = {
@@ -130,7 +133,8 @@ const winterDefaults: ScenarioDefaults = {
     ambientTemp_C: 20,
     targetTemp_C: 55,
     initialTemp_C: 35
-  }
+  },
+  tariffs: cloneTariffs(defaultTariffs)
 };
 
 const coldMorningDefaults: ScenarioDefaults = {
@@ -151,7 +155,8 @@ const coldMorningDefaults: ScenarioDefaults = {
     ambientTemp_C: 20,
     targetTemp_C: 55,
     initialTemp_C: 15
-  }
+  },
+  tariffs: cloneTariffs(defaultTariffs)
 };
 
 const emptyBatteryDefaults: ScenarioDefaults = {
@@ -172,7 +177,8 @@ const emptyBatteryDefaults: ScenarioDefaults = {
     ambientTemp_C: 20,
     targetTemp_C: 55,
     initialTemp_C: 35  // Résolu : température ECS ajustée pour divergence
-  }
+  },
+  tariffs: cloneTariffs(defaultTariffs)
 };
 
 const summerSunny: ScenarioPreset = {
@@ -266,7 +272,8 @@ export const getScenario = (preset: PresetId): ScenarioConfig => {
     dt: series.dt_s,
     pv: series.pvSeries_kW,
     load_base: series.baseLoadSeries_kW,
-    defaults: cloneDefaults(definition.defaults)
+    defaults: cloneDefaults(definition.defaults),
+    tariffs: cloneTariffs(definition.defaults.tariffs)
   };
 };
 

--- a/src/data/tariffs.ts
+++ b/src/data/tariffs.ts
@@ -1,0 +1,136 @@
+import { Tariffs } from './types';
+
+const SECONDS_PER_DAY = 24 * 3600;
+
+const normalizeHour = (hour: number): number => {
+  const normalized = Math.floor(hour);
+  if (!Number.isFinite(normalized)) {
+    return 0;
+  }
+  const mod = normalized % 24;
+  return mod < 0 ? mod + 24 : mod;
+};
+
+const complementHours = (hours: number[]): number[] => {
+  const set = new Set(hours.map(normalizeHour));
+  const result: number[] = [];
+  for (let hour = 0; hour < 24; hour += 1) {
+    if (!set.has(hour)) {
+      result.push(hour);
+    }
+  }
+  return result;
+};
+
+const repeatValue = (value: number, steps: number): number[] => {
+  const arr = new Array(steps);
+  for (let i = 0; i < steps; i += 1) {
+    arr[i] = value;
+  }
+  return arr;
+};
+
+const projectProfile = (profile: number[], steps: number, dt_s: number): number[] => {
+  if (profile.length === 0) {
+    return repeatValue(0, steps);
+  }
+  if (profile.length === steps) {
+    return profile.slice();
+  }
+  const projected = new Array(steps);
+  for (let i = 0; i < steps; i += 1) {
+    const time_s = (i * dt_s) % SECONDS_PER_DAY;
+    const ratio = time_s / SECONDS_PER_DAY;
+    const rawIndex = Math.floor(ratio * profile.length);
+    const index = Math.min(profile.length - 1, rawIndex);
+    projected[i] = profile[index];
+  }
+  return projected;
+};
+
+const ensureArray = (input: number | number[] | undefined, steps: number, dt_s: number): number[] => {
+  if (Array.isArray(input)) {
+    return projectProfile(input, steps, dt_s);
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return repeatValue(input, steps);
+  }
+  return repeatValue(0, steps);
+};
+
+export const cloneTariffs = (tariffs: Tariffs): Tariffs => ({
+  mode: tariffs.mode,
+  import_EUR_per_kWh: Array.isArray(tariffs.import_EUR_per_kWh)
+    ? [...tariffs.import_EUR_per_kWh]
+    : tariffs.import_EUR_per_kWh,
+  export_EUR_per_kWh: Array.isArray(tariffs.export_EUR_per_kWh)
+    ? [...tariffs.export_EUR_per_kWh]
+    : tariffs.export_EUR_per_kWh,
+  tou: tariffs.tou
+    ? {
+        onpeak_hours: [...tariffs.tou.onpeak_hours],
+        offpeak_hours: [...tariffs.tou.offpeak_hours],
+        onpeak_price: tariffs.tou.onpeak_price,
+        offpeak_price: tariffs.tou.offpeak_price
+      }
+    : undefined
+});
+
+export const defaultTariffs: Tariffs = {
+  mode: 'fixed',
+  import_EUR_per_kWh: 0.25,
+  export_EUR_per_kWh: 0.1,
+  tou: {
+    onpeak_hours: [7, 8, 9, 18, 19, 20, 21, 22],
+    offpeak_hours: complementHours([7, 8, 9, 18, 19, 20, 21, 22]),
+    onpeak_price: 0.3,
+    offpeak_price: 0.18
+  }
+};
+
+export const resolvePrices = (
+  tariffs: Tariffs,
+  steps: number,
+  dt_s: number
+): { importPrices: number[]; exportPrices: number[] } => {
+  if (steps <= 0 || dt_s <= 0) {
+    return { importPrices: [], exportPrices: [] };
+  }
+
+  const safeSteps = Math.floor(steps);
+
+  if (tariffs.mode === 'tou') {
+    const tou = tariffs.tou ?? defaultTariffs.tou!;
+    const onPeakSet = new Set((tou.onpeak_hours ?? []).map(normalizeHour));
+
+    const importPrices = new Array(safeSteps);
+    for (let i = 0; i < safeSteps; i += 1) {
+      const hour = normalizeHour(Math.floor(((i * dt_s) / 3600) % 24));
+      importPrices[i] = onPeakSet.has(hour) ? tou.onpeak_price : tou.offpeak_price;
+    }
+
+    return {
+      importPrices,
+      exportPrices: ensureArray(tariffs.export_EUR_per_kWh, safeSteps, dt_s)
+    };
+  }
+
+  if (tariffs.mode === 'profile') {
+    return {
+      importPrices: ensureArray(tariffs.import_EUR_per_kWh, safeSteps, dt_s),
+      exportPrices: ensureArray(tariffs.export_EUR_per_kWh, safeSteps, dt_s)
+    };
+  }
+
+  return {
+    importPrices: ensureArray(tariffs.import_EUR_per_kWh, safeSteps, dt_s),
+    exportPrices: ensureArray(tariffs.export_EUR_per_kWh, safeSteps, dt_s)
+  };
+};
+
+export const deriveTouConfig = (onPeak: number[]): Tariffs['tou'] => ({
+  onpeak_hours: onPeak.map(normalizeHour),
+  offpeak_hours: complementHours(onPeak),
+  onpeak_price: defaultTariffs.tou!.onpeak_price,
+  offpeak_price: defaultTariffs.tou!.offpeak_price
+});

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,6 +1,22 @@
 import type { BatteryParams } from '../devices/Battery';
 import type { DHWTankParams } from '../devices/DHWTank';
 
+export type TariffMode = 'fixed' | 'tou' | 'profile';
+
+export interface TimeOfUseConfig {
+  onpeak_hours: number[];
+  offpeak_hours: number[];
+  onpeak_price: number;
+  offpeak_price: number;
+}
+
+export interface Tariffs {
+  mode: TariffMode;
+  import_EUR_per_kWh: number | number[];
+  export_EUR_per_kWh: number | number[];
+  tou?: TimeOfUseConfig;
+}
+
 /**
  * Types de données utilisées pour les scénarios et les séries temporelles
  * alimentant le moteur de simulation.
@@ -17,6 +33,7 @@ export interface ScenarioSeries {
 export interface ScenarioDefaults {
   readonly batteryConfig: BatteryParams;
   readonly ecsConfig: DHWTankParams;
+  readonly tariffs: Tariffs;
 }
 
 export interface ScenarioPreset {
@@ -34,6 +51,7 @@ export interface ScenarioConfig {
   readonly pv: readonly number[];
   readonly load_base: readonly number[];
   readonly defaults: ScenarioDefaults;
+  readonly tariffs: Tariffs;
 }
 
 export interface StepFlows {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,9 +3,12 @@ import ScenarioPanel from './panels/ScenarioPanel';
 import AssetsPanel from './panels/AssetsPanel';
 import StrategyPanel, { StrategySelection } from './panels/StrategyPanel';
 import CompareAB from './compare/CompareAB';
+import TariffPanel from './panels/TariffPanel';
 import type { BatteryParams } from '../devices/Battery';
 import type { DHWTankParams } from '../devices/DHWTank';
+import type { Tariffs } from '../data/types';
 import { getScenario, PresetId } from '../data/scenarios';
+import { cloneTariffs } from '../data/tariffs';
 
 const App: React.FC = () => {
   const initialScenario = getScenario(PresetId.EteEnsoleille);
@@ -19,12 +22,14 @@ const App: React.FC = () => {
   });
   const [strategyA, setStrategyA] = useState<StrategySelection>({ id: 'ecs_first' });
   const [strategyB, setStrategyB] = useState<StrategySelection>({ id: 'battery_first' });
+  const [tariffs, setTariffs] = useState<Tariffs>(cloneTariffs(initialScenario.tariffs));
 
   useEffect(() => {
     const scenario = getScenario(scenarioId);
     setDt(scenario.dt);
     setBatteryParams({ ...scenario.defaults.batteryConfig });
     setDhwParams({ ...scenario.defaults.ecsConfig });
+    setTariffs(cloneTariffs(scenario.tariffs));
   }, [scenarioId]);
 
   const handleStrategyChange = (label: 'A' | 'B', selection: StrategySelection) => {
@@ -45,8 +50,9 @@ const App: React.FC = () => {
           </p>
         </header>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 space-y-6">
             <ScenarioPanel scenarioId={scenarioId} dt_s={dt_s} onScenarioChange={setScenarioId} onDtChange={setDt} />
+            <TariffPanel tariffs={tariffs} onChange={setTariffs} />
           </div>
           <div className="lg:col-span-2">
             <AssetsPanel battery={batteryParams} dhw={dhwParams} onBatteryChange={setBatteryParams} onDhwChange={setDhwParams} />
@@ -60,6 +66,7 @@ const App: React.FC = () => {
           dt_s={dt_s}
           battery={batteryParams}
           dhw={dhwParams}
+          tariffs={tariffs}
           strategyA={strategyA}
           strategyB={strategyB}
         />

--- a/src/ui/panels/TariffPanel.tsx
+++ b/src/ui/panels/TariffPanel.tsx
@@ -1,0 +1,363 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { Tariffs, TariffMode } from '../../data/types';
+import { cloneTariffs, defaultTariffs } from '../../data/tariffs';
+import { formatPrice } from '../utils/ui';
+
+interface TariffPanelProps {
+  tariffs: Tariffs;
+  onChange: (tariffs: Tariffs) => void;
+}
+
+const hourOptions = Array.from({ length: 24 }, (_, index) => index);
+
+const complementHours = (hours: number[]): number[] => {
+  const set = new Set(hours);
+  const result: number[] = [];
+  for (let hour = 0; hour < 24; hour += 1) {
+    if (!set.has(hour)) {
+      result.push(hour);
+    }
+  }
+  return result;
+};
+
+const asPositiveNumber = (value: string, fallback: number): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(parsed, 0);
+};
+
+const ensureProfileArray = (value: number | number[] | undefined, fallback: number): number[] => {
+  if (Array.isArray(value) && value.length > 0) {
+    return [...value];
+  }
+  return new Array(24).fill(fallback);
+};
+
+const parseProfileText = (text: string): number[] | null => {
+  try {
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return null;
+    }
+    const values = parsed.map((entry) => Number(entry));
+    if (values.some((value) => !Number.isFinite(value) || value < 0)) {
+      return null;
+    }
+    if (values.length !== 24 && values.length !== 96) {
+      return null;
+    }
+    return values;
+  } catch (error) {
+    return null;
+  }
+};
+
+const TariffPanel: React.FC<TariffPanelProps> = ({ tariffs, onChange }) => {
+  const [profileImportText, setProfileImportText] = useState('');
+  const [profileExportText, setProfileExportText] = useState('');
+  const [profileErrors, setProfileErrors] = useState<{ import?: string; export?: string }>({});
+
+  const exportPriceDisplay = useMemo(() => {
+    if (Array.isArray(tariffs.export_EUR_per_kWh)) {
+      return formatPrice(tariffs.export_EUR_per_kWh[0] ?? 0);
+    }
+    return formatPrice(typeof tariffs.export_EUR_per_kWh === 'number' ? tariffs.export_EUR_per_kWh : 0);
+  }, [tariffs.export_EUR_per_kWh]);
+
+  useEffect(() => {
+    if (tariffs.mode === 'profile') {
+      const importProfile = ensureProfileArray(
+        tariffs.import_EUR_per_kWh,
+        typeof tariffs.import_EUR_per_kWh === 'number'
+          ? tariffs.import_EUR_per_kWh
+          : (defaultTariffs.import_EUR_per_kWh as number)
+      );
+      const exportProfile = ensureProfileArray(
+        tariffs.export_EUR_per_kWh,
+        typeof tariffs.export_EUR_per_kWh === 'number'
+          ? tariffs.export_EUR_per_kWh
+          : (defaultTariffs.export_EUR_per_kWh as number)
+      );
+      setProfileImportText(JSON.stringify(importProfile));
+      setProfileExportText(JSON.stringify(exportProfile));
+      setProfileErrors({});
+    } else {
+      setProfileErrors({});
+    }
+  }, [tariffs]);
+
+  const handleModeChange = (mode: TariffMode) => {
+    if (mode === tariffs.mode) {
+      return;
+    }
+    const next = cloneTariffs(tariffs);
+    next.mode = mode;
+    if (mode === 'fixed') {
+      const importValue = Array.isArray(next.import_EUR_per_kWh)
+        ? next.import_EUR_per_kWh[0] ?? (defaultTariffs.import_EUR_per_kWh as number)
+        : (next.import_EUR_per_kWh as number);
+      const exportValue = Array.isArray(next.export_EUR_per_kWh)
+        ? next.export_EUR_per_kWh[0] ?? (defaultTariffs.export_EUR_per_kWh as number)
+        : (next.export_EUR_per_kWh as number);
+      next.import_EUR_per_kWh = importValue;
+      next.export_EUR_per_kWh = exportValue;
+    } else if (mode === 'tou') {
+      const base = next.tou ?? cloneTariffs(defaultTariffs).tou!;
+      next.import_EUR_per_kWh = Array.isArray(next.import_EUR_per_kWh)
+        ? next.import_EUR_per_kWh[0] ?? base.offpeak_price
+        : next.import_EUR_per_kWh;
+      next.export_EUR_per_kWh = Array.isArray(next.export_EUR_per_kWh)
+        ? next.export_EUR_per_kWh[0] ?? (defaultTariffs.export_EUR_per_kWh as number)
+        : next.export_EUR_per_kWh;
+      next.tou = {
+        onpeak_hours: [...base.onpeak_hours],
+        offpeak_hours: [...base.offpeak_hours],
+        onpeak_price: base.onpeak_price,
+        offpeak_price: base.offpeak_price
+      };
+    } else if (mode === 'profile') {
+      const importValue = Array.isArray(next.import_EUR_per_kWh)
+        ? next.import_EUR_per_kWh
+        : ensureProfileArray(
+            undefined,
+            typeof next.import_EUR_per_kWh === 'number'
+              ? next.import_EUR_per_kWh
+              : (defaultTariffs.import_EUR_per_kWh as number)
+          );
+      const exportValue = Array.isArray(next.export_EUR_per_kWh)
+        ? next.export_EUR_per_kWh
+        : ensureProfileArray(
+            undefined,
+            typeof next.export_EUR_per_kWh === 'number'
+              ? next.export_EUR_per_kWh
+              : (defaultTariffs.export_EUR_per_kWh as number)
+          );
+      next.import_EUR_per_kWh = importValue;
+      next.export_EUR_per_kWh = exportValue;
+    }
+    onChange(next);
+  };
+
+  const updateImportPrice = (value: number) => {
+    const next = cloneTariffs(tariffs);
+    next.import_EUR_per_kWh = value;
+    onChange(next);
+  };
+
+  const updateExportPrice = (value: number) => {
+    const next = cloneTariffs(tariffs);
+    next.export_EUR_per_kWh = value;
+    onChange(next);
+  };
+
+  const updateTouPrice = (key: 'onpeak_price' | 'offpeak_price', value: number) => {
+    const base = tariffs.tou ?? cloneTariffs(defaultTariffs).tou!;
+    const next = cloneTariffs(tariffs);
+    next.tou = {
+      onpeak_hours: [...(tariffs.tou?.onpeak_hours ?? base.onpeak_hours)],
+      offpeak_hours: [...(tariffs.tou?.offpeak_hours ?? base.offpeak_hours)],
+      onpeak_price: key === 'onpeak_price' ? value : tariffs.tou?.onpeak_price ?? base.onpeak_price,
+      offpeak_price: key === 'offpeak_price' ? value : tariffs.tou?.offpeak_price ?? base.offpeak_price
+    };
+    onChange(next);
+  };
+
+  const updateTouHours = (hours: number[]) => {
+    const base = tariffs.tou ?? cloneTariffs(defaultTariffs).tou!;
+    const next = cloneTariffs(tariffs);
+    next.tou = {
+      onpeak_hours: [...hours],
+      offpeak_hours: complementHours(hours),
+      onpeak_price: tariffs.tou?.onpeak_price ?? base.onpeak_price,
+      offpeak_price: tariffs.tou?.offpeak_price ?? base.offpeak_price
+    };
+    onChange(next);
+  };
+
+  const handleProfileChange = (kind: 'import' | 'export', text: string) => {
+    if (kind === 'import') {
+      setProfileImportText(text);
+    } else {
+      setProfileExportText(text);
+    }
+    if (text.trim().length === 0) {
+      setProfileErrors((prev) => ({ ...prev, [kind]: 'Le profil doit contenir des valeurs numériques.' }));
+      return;
+    }
+    const parsed = parseProfileText(text);
+    if (!parsed) {
+      setProfileErrors((prev) => ({ ...prev, [kind]: 'Utilisez un tableau JSON de 24 ou 96 valeurs ≥ 0.' }));
+      return;
+    }
+    setProfileErrors((prev) => ({ ...prev, [kind]: undefined }));
+    const next = cloneTariffs(tariffs);
+    if (kind === 'import') {
+      next.import_EUR_per_kWh = parsed;
+    } else {
+      next.export_EUR_per_kWh = parsed;
+    }
+    onChange(next);
+  };
+
+  return (
+    <section className="bg-white shadow rounded p-4 space-y-4 text-sm">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-slate-800">Tarifs</h2>
+        <p className="text-xs text-slate-500">
+          Configurez le coût d&apos;import réseau et le tarif de rachat pour alimenter les KPIs en €.
+        </p>
+      </header>
+
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-slate-600" htmlFor="tariff-mode">
+          Mode de tarification
+        </label>
+        <select
+          id="tariff-mode"
+          className="w-full rounded border border-slate-300 p-2"
+          value={tariffs.mode}
+          onChange={(event) => handleModeChange(event.target.value as TariffMode)}
+        >
+          <option value="fixed">Fixe</option>
+          <option value="tou">Heures pleines/creuses</option>
+          <option value="profile">Profil journalier</option>
+        </select>
+      </div>
+
+      {tariffs.mode === 'fixed' ? (
+        <div className="grid grid-cols-1 gap-3">
+          <label className="text-xs font-medium text-slate-600">
+            Prix import (€/kWh)
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              className="mt-1 w-full rounded border border-slate-300 p-2"
+              value={typeof tariffs.import_EUR_per_kWh === 'number' ? tariffs.import_EUR_per_kWh : 0}
+              onChange={(event) => updateImportPrice(asPositiveNumber(event.target.value, 0))}
+            />
+          </label>
+          <label className="text-xs font-medium text-slate-600">
+            Prix rachat (€/kWh)
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              className="mt-1 w-full rounded border border-slate-300 p-2"
+              value={typeof tariffs.export_EUR_per_kWh === 'number' ? tariffs.export_EUR_per_kWh : 0}
+              onChange={(event) => updateExportPrice(asPositiveNumber(event.target.value, 0))}
+            />
+          </label>
+        </div>
+      ) : null}
+
+      {tariffs.mode === 'tou' ? (
+        <div className="space-y-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="text-xs font-medium text-slate-600">
+              Prix heures pleines (€/kWh)
+              <input
+                type="number"
+                min={0}
+                step={0.01}
+                className="mt-1 w-full rounded border border-slate-300 p-2"
+                value={tariffs.tou?.onpeak_price ?? cloneTariffs(defaultTariffs).tou!.onpeak_price}
+                onChange={(event) => updateTouPrice('onpeak_price', asPositiveNumber(event.target.value, 0))}
+              />
+            </label>
+            <label className="text-xs font-medium text-slate-600">
+              Prix heures creuses (€/kWh)
+              <input
+                type="number"
+                min={0}
+                step={0.01}
+                className="mt-1 w-full rounded border border-slate-300 p-2"
+                value={tariffs.tou?.offpeak_price ?? cloneTariffs(defaultTariffs).tou!.offpeak_price}
+                onChange={(event) => updateTouPrice('offpeak_price', asPositiveNumber(event.target.value, 0))}
+              />
+            </label>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-slate-600" htmlFor="tou-hours">
+              Heures pleines
+            </label>
+            <select
+              id="tou-hours"
+              multiple
+              className="h-32 w-full rounded border border-slate-300 p-2"
+              value={(tariffs.tou?.onpeak_hours ?? cloneTariffs(defaultTariffs).tou!.onpeak_hours).map(String)}
+              onChange={(event) => {
+                const selected = Array.from(event.target.selectedOptions).map((option) => Number(option.value));
+                updateTouHours(selected);
+              }}
+            >
+              {hourOptions.map((hour) => (
+                <option key={hour} value={hour}>
+                  {hour.toString().padStart(2, '0')} h
+                </option>
+              ))}
+            </select>
+            <p className="text-[11px] text-slate-500">
+              Les heures restantes ({complementHours(tariffs.tou?.onpeak_hours ?? [])
+                .map((hour) => hour.toString().padStart(2, '0'))
+                .join(', ') || '—'} h) seront considérées comme heures creuses.
+            </p>
+          </div>
+          <label className="text-xs font-medium text-slate-600">
+            Prix rachat constant (€/kWh)
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              className="mt-1 w-full rounded border border-slate-300 p-2"
+              value={typeof tariffs.export_EUR_per_kWh === 'number' ? tariffs.export_EUR_per_kWh : 0}
+              onChange={(event) => updateExportPrice(asPositiveNumber(event.target.value, 0))}
+            />
+          </label>
+        </div>
+      ) : null}
+
+      {tariffs.mode === 'profile' ? (
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs font-medium text-slate-600" htmlFor="profile-import">
+              Profil import (24 ou 96 valeurs €/kWh)
+            </label>
+            <textarea
+              id="profile-import"
+              className="mt-1 h-32 w-full rounded border border-slate-300 p-2 font-mono text-xs"
+              value={profileImportText}
+              onChange={(event) => handleProfileChange('import', event.target.value)}
+            />
+            {profileErrors.import ? (
+              <p className="mt-1 text-[11px] text-red-600">{profileErrors.import}</p>
+            ) : null}
+          </div>
+          <div>
+            <label className="text-xs font-medium text-slate-600" htmlFor="profile-export">
+              Profil rachat (24 ou 96 valeurs €/kWh)
+            </label>
+            <textarea
+              id="profile-export"
+              className="mt-1 h-32 w-full rounded border border-slate-300 p-2 font-mono text-xs"
+              value={profileExportText}
+              onChange={(event) => handleProfileChange('export', event.target.value)}
+            />
+            {profileErrors.export ? (
+              <p className="mt-1 text-[11px] text-red-600">{profileErrors.export}</p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <p className="text-[11px] text-slate-400">
+        Tarif export courant : <span className="font-semibold">{exportPriceDisplay}</span>
+      </p>
+    </section>
+  );
+};
+
+export default TariffPanel;

--- a/src/ui/utils/ui.ts
+++ b/src/ui/utils/ui.ts
@@ -14,6 +14,14 @@ export const formatDelta = (value: number, fractionDigits = 1, suffix = ''): str
   return `${sign}${Math.abs(value).toFixed(fractionDigits)}${suffixPart}`;
 };
 
+export const formatEUR = (value: number, fractionDigits = 2): string => {
+  const sign = value < 0 ? '−' : '';
+  return `${sign}${Math.abs(value).toFixed(fractionDigits)} €`;
+};
+
+export const formatPrice = (value: number, fractionDigits = 3): string =>
+  `${value.toFixed(fractionDigits)} €/kWh`;
+
 export const formatPercent = (value: number, fractionDigits = 1): string =>
   formatPct(value, fractionDigits);
 

--- a/tests/engine_minimal.test.ts
+++ b/tests/engine_minimal.test.ts
@@ -71,6 +71,12 @@ describe('Moteur de simulation — scénario été', () => {
       6
     );
 
+    expect(result.kpis.euros.cost_import).toBeGreaterThanOrEqual(0);
+    expect(result.kpis.euros.net_cost).toBeCloseTo(
+      result.kpis.euros.cost_import - result.kpis.euros.revenue_export,
+      6
+    );
+
     for (const step of result.steps) {
       const batteryState = step.deviceStates.find((device) => device.id === 'battery');
       if (batteryState) {


### PR DESCRIPTION
## Summary
- add tariff data structures, default values, and price resolution in the simulation core
- compute euro KPIs from grid flows and expose them in the comparison UI with dedicated formatting
- add a tariff configuration panel and propagate pricing through the worker and tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb931c8848322bf3a3f410b47262f