### PR TITLE
Guarantee ECS hot water rescue compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ KPIs : Autoconsommation, Autoproduction, € économisés (optionnel), proxy cyc
 
 UI : Comparateur A/B avec graphiques synchronisés + export CSV/JSON
 
+Comparaisons : Appoint réseau automatique garantissant un ballon ECS conforme dans chaque scénario
+
 🗺️ Roadmap courte
 
 S1 : Core + Batterie + ECS + UI de base + tests

--- a/src/core/kpis.ts
+++ b/src/core/kpis.ts
@@ -15,12 +15,17 @@ export interface KPIInput {
   exportPrices_EUR_per_kWh: readonly number[];
 }
 
-export interface SimulationKPIs {
+export interface SimulationKPIsCore {
   selfConsumption: number;
   selfProduction: number;
   batteryCycles: number;
   ecsTargetUptime: number;
   euros: EuroKPIs;
+}
+
+export interface SimulationKPIs extends SimulationKPIsCore {
+  ecs_rescue_used: boolean;
+  ecs_rescue_kWh: number;
 }
 
 export interface EuroKPIs {
@@ -83,7 +88,7 @@ export const ecsTargetUptime = (input: KPIInput): number => {
   return count / input.ecsTempSeries_C.length;
 };
 
-export const computeKPIs = (input: KPIInput): SimulationKPIs => ({
+export const computeKPIs = (input: KPIInput): SimulationKPIsCore => ({
   selfConsumption: selfConsumption(input),
   selfProduction: selfProduction(input),
   batteryCycles: batteryCyclesProxy(input),

--- a/src/devices/DHWTank.ts
+++ b/src/devices/DHWTank.ts
@@ -10,7 +10,7 @@ export interface DHWTankParams {
   initialTemp_C: number;
 }
 
-const WATER_HEAT_CAPACITY_WH_PER_L_PER_K = 1.163;
+export const WATER_HEAT_CAPACITY_WH_PER_L_PER_K = 1.163;
 
 /**
  * Modèle simple de ballon ECS (stockage thermique).
@@ -71,6 +71,14 @@ export class DHWTank implements Device {
 
   public get targetTemp(): number {
     return this.params.targetTemp_C;
+  }
+
+  public get volume_L(): number {
+    return this.params.volume_L;
+  }
+
+  public enforceTargetTemperature(): void {
+    this.temp_C = this.params.targetTemp_C;
   }
 }
 

--- a/src/ui/compare/CompareAB.tsx
+++ b/src/ui/compare/CompareAB.tsx
@@ -257,6 +257,11 @@ const CompareAB: React.FC<CompareABProps> = ({
       label: 'Export réseau',
       valueA: resultA ? formatKWh(resultA.totals.gridExport_kWh) : '—',
       valueB: resultB ? formatKWh(resultB.totals.gridExport_kWh) : '—'
+    },
+    {
+      label: 'Secours ECS',
+      valueA: resultA ? formatKWh(resultA.totals.ecsRescue_kWh) : '—',
+      valueB: resultB ? formatKWh(resultB.totals.ecsRescue_kWh) : '—'
     }
   ];
 
@@ -350,6 +355,19 @@ const CompareAB: React.FC<CompareABProps> = ({
       </div>
 
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-2">
+        {resultA?.kpis.ecs_rescue_used ? (
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            ⚠️ Secours réseau ECS utilisé (Stratégie A)
+          </span>
+        ) : null}
+        {resultB?.kpis.ecs_rescue_used ? (
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            ⚠️ Secours réseau ECS utilisé (Stratégie B)
+          </span>
+        ) : null}
+      </div>
 
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-200 text-sm">

--- a/tests/ecs_rescue.test.ts
+++ b/tests/ecs_rescue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getScenario, PresetId } from '../src/data/scenarios';
+import { DHWTank } from '../src/devices/DHWTank';
+import { runSimulation } from '../src/core/engine';
+import { ecsFirstStrategy, Strategy } from '../src/core/strategy';
+
+const createTank = (preset: PresetId): DHWTank => {
+  const scenario = getScenario(preset);
+  return new DHWTank('dhw', 'Ballon ECS', { ...scenario.defaults.ecsConfig });
+};
+
+describe('Appoint réseau ECS automatique', () => {
+  it('applique un secours lorsque la stratégie ignore totalement le ballon', () => {
+    const scenario = getScenario(PresetId.HiverCouvert);
+    const tank = createTank(PresetId.HiverCouvert);
+    const ignoreStrategy: Strategy = () => [];
+
+    const result = runSimulation({
+      dt_s: scenario.dt,
+      pvSeries_kW: scenario.pv,
+      baseLoadSeries_kW: scenario.load_base,
+      devices: [tank],
+      strategy: ignoreStrategy
+    });
+
+    expect(result.kpis.ecs_rescue_used).toBe(true);
+    expect(result.kpis.ecs_rescue_kWh).toBeGreaterThan(0);
+    expect(result.totals.ecsRescue_kWh).toBeCloseTo(result.kpis.ecs_rescue_kWh, 6);
+    expect(tank.temperature).toBeCloseTo(tank.targetTemp, 6);
+
+    const lastStep = result.steps[result.steps.length - 1];
+    const dhwState = lastStep.deviceStates.find((device) => device.id === 'dhw');
+    expect(dhwState).toBeDefined();
+    expect(Number(dhwState?.state.temp_C)).toBeCloseTo(tank.targetTemp, 6);
+  });
+
+  it("n'emploie pas de secours quand l'ECS est déjà conforme", () => {
+    const scenario = getScenario(PresetId.EteEnsoleille);
+    const tank = new DHWTank('dhw', 'Ballon ECS', {
+      ...scenario.defaults.ecsConfig,
+      initialTemp_C: scenario.defaults.ecsConfig.targetTemp_C
+    });
+
+    const result = runSimulation({
+      dt_s: scenario.dt,
+      pvSeries_kW: scenario.pv,
+      baseLoadSeries_kW: scenario.load_base,
+      devices: [tank],
+      strategy: ecsFirstStrategy
+    });
+
+    expect(result.kpis.ecs_rescue_used).toBe(false);
+    expect(result.kpis.ecs_rescue_kWh).toBe(0);
+    expect(result.totals.ecsRescue_kWh).toBe(0);
+    expect(tank.temperature).toBeCloseTo(tank.targetTemp, 6);
+  });
+});


### PR DESCRIPTION
## Summary
- add a post-simulation ECS rescue that tops up tanks to their target temperature via grid imports and tracks the associated energy
- surface rescue usage in KPI results, comparison totals, and documentation to make A/B reviews explicit
- add regression tests covering rescue activation and non-activation scenarios

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68cef978c33c8322984e7bc12cbe62db