### PR TITLE
Add contextual tooltips for key KPIs and asset form fields

### DIFF
--- a/src/ui/compare/CompareAB.tsx
+++ b/src/ui/compare/CompareAB.tsx
@@ -9,6 +9,8 @@ import { summarizeFlows } from '../../core/kpis';
 import type { StepFlows, Tariffs } from '../../data/types';
 import PVLoadChart from '../charts/PVLoadChart';
 import SocChart from '../charts/SocChart';
+import KpiItem from '../components/KpiItem';
+import { HELP } from '../help';
 import { StrategySelection } from '../panels/StrategyPanel';
 import {
   downloadCSV,
@@ -156,6 +158,7 @@ const CompareAB: React.FC<CompareABProps> = ({
     deltaFormatter: (delta: number) => string;
     deltaThreshold: number;
     preferHigher?: boolean;
+    helpKey?: keyof typeof HELP.kpi;
   };
 
   const kpiRows: KpiRow[] = [
@@ -165,7 +168,8 @@ const CompareAB: React.FC<CompareABProps> = ({
       valueB: resultB?.kpis.selfConsumption,
       formatter: (value: number) => formatPct(value),
       deltaFormatter: (delta: number) => formatDelta(delta * 100, 1, ' %'),
-      deltaThreshold: 0.001
+      deltaThreshold: 0.001,
+      helpKey: 'selfConsumption'
     },
     {
       label: 'Autoproduction',
@@ -173,7 +177,8 @@ const CompareAB: React.FC<CompareABProps> = ({
       valueB: resultB?.kpis.selfProduction,
       formatter: (value: number) => formatPct(value),
       deltaFormatter: (delta: number) => formatDelta(delta * 100, 1, ' %'),
-      deltaThreshold: 0.001
+      deltaThreshold: 0.001,
+      helpKey: 'selfProduction'
     },
     {
       label: 'Cycles batterie (proxy)',
@@ -181,7 +186,8 @@ const CompareAB: React.FC<CompareABProps> = ({
       valueB: resultB?.kpis.batteryCycles,
       formatter: (value: number) => formatCycles(value),
       deltaFormatter: (delta: number) => formatDelta(delta, 2),
-      deltaThreshold: 0.05
+      deltaThreshold: 0.05,
+      helpKey: 'cycles'
     },
     {
       label: 'Temps ECS ≥ cible',
@@ -219,7 +225,8 @@ const CompareAB: React.FC<CompareABProps> = ({
       formatter: (value: number) => formatEUR(value),
       deltaFormatter: (delta: number) => formatDelta(delta, 2, '€'),
       deltaThreshold: 0.1,
-      preferHigher: false
+      preferHigher: false,
+      helpKey: 'netCost'
     },
     {
       label: 'Économies vs sans PV',
@@ -379,27 +386,27 @@ const CompareAB: React.FC<CompareABProps> = ({
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200">
-            {[...kpiRows, ...euroRows].map((row) => (
-              <tr key={row.label}>
-                <td className="py-2 font-medium text-slate-700">
-                  <span>{row.label}</span>
-                  {row.valueA !== undefined && row.valueB !== undefined
-                    ? renderDeltaBadge(
-                        row.valueA - row.valueB,
-                        row.deltaThreshold,
-                        row.deltaFormatter,
-                        row.preferHigher ?? true
-                      )
-                    : null}
-                </td>
-                <td className="py-2 text-slate-800">
-                  {row.valueA !== undefined ? row.formatter(row.valueA) : '—'}
-                </td>
-                <td className="py-2 text-slate-800">
-                  {row.valueB !== undefined ? row.formatter(row.valueB) : '—'}
-                </td>
-              </tr>
-            ))}
+            {[...kpiRows, ...euroRows].map((row) => {
+              const hasBoth = row.valueA !== undefined && row.valueB !== undefined;
+              const delta = hasBoth
+                ? renderDeltaBadge(
+                    (row.valueA ?? 0) - (row.valueB ?? 0),
+                    row.deltaThreshold,
+                    row.deltaFormatter,
+                    row.preferHigher ?? true
+                  )
+                : null;
+              return (
+                <KpiItem
+                  key={row.label}
+                  label={row.label}
+                  valueA={row.valueA !== undefined ? row.formatter(row.valueA) : '—'}
+                  valueB={row.valueB !== undefined ? row.formatter(row.valueB) : '—'}
+                  delta={delta}
+                  help={row.helpKey ? HELP.kpi[row.helpKey] : undefined}
+                />
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/ui/components/FieldLabel.tsx
+++ b/src/ui/components/FieldLabel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Tooltip from './Tooltip';
+
+interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  label: React.ReactNode;
+  help?: string;
+  children: React.ReactNode;
+}
+
+const infoIconClasses =
+  'ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-slate-700/20 text-[10px] font-semibold text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400';
+
+const FieldLabel: React.FC<FieldLabelProps> = ({ label, help, children, className = '', ...props }) => {
+  return (
+    <label className={`block text-sm text-slate-600 ${className}`.trim()} {...props}>
+      <span className="mb-1 flex items-center">
+        <span>{label}</span>
+        {help ? (
+          <Tooltip content={help}>
+            <span tabIndex={0} aria-label="Informations" className={infoIconClasses}>
+              ⓘ
+            </span>
+          </Tooltip>
+        ) : null}
+      </span>
+      {children}
+    </label>
+  );
+};
+
+export default FieldLabel;

--- a/src/ui/components/KpiItem.tsx
+++ b/src/ui/components/KpiItem.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Tooltip from './Tooltip';
+
+interface KpiItemProps {
+  label: React.ReactNode;
+  valueA: React.ReactNode;
+  valueB: React.ReactNode;
+  delta?: React.ReactNode;
+  help?: string;
+}
+
+const infoIconClasses =
+  'ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-slate-700/20 text-[10px] font-semibold text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400';
+
+const KpiItem: React.FC<KpiItemProps> = ({ label, valueA, valueB, delta, help }) => {
+  return (
+    <tr>
+      <td className="py-2 font-medium text-slate-700">
+        <div className="flex items-center">
+          <span>{label}</span>
+          {help ? (
+            <Tooltip content={help}>
+              <span tabIndex={0} aria-label="Informations" className={infoIconClasses}>
+                ⓘ
+              </span>
+            </Tooltip>
+          ) : null}
+          {delta ?? null}
+        </div>
+      </td>
+      <td className="py-2 text-slate-800">{valueA}</td>
+      <td className="py-2 text-slate-800">{valueB}</td>
+    </tr>
+  );
+};
+
+export default KpiItem;

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -1,0 +1,62 @@
+import React, { useId, useState } from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactElement;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ content, children }) => {
+  const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
+
+  const show = () => setVisible(true);
+  const hide = () => setVisible(false);
+
+  const childProps: Partial<React.DOMAttributes<HTMLElement>> & {
+    'aria-describedby': string;
+  } = {
+    onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+      if (children.props.onMouseEnter) {
+        children.props.onMouseEnter(event);
+      }
+      show();
+    },
+    onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+      if (children.props.onMouseLeave) {
+        children.props.onMouseLeave(event);
+      }
+      hide();
+    },
+    onFocus: (event: React.FocusEvent<HTMLElement>) => {
+      if (children.props.onFocus) {
+        children.props.onFocus(event);
+      }
+      show();
+    },
+    onBlur: (event: React.FocusEvent<HTMLElement>) => {
+      if (children.props.onBlur) {
+        children.props.onBlur(event);
+      }
+      hide();
+    },
+    'aria-describedby': [children.props['aria-describedby'], tooltipId].filter(Boolean).join(' ')
+  };
+
+  return (
+    <span className="relative inline-flex">
+      {React.cloneElement(children, childProps)}
+      <span
+        role="tooltip"
+        id={tooltipId}
+        className={`pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded bg-black/80 px-2 py-1 text-xs text-white shadow transition-opacity duration-150 ${
+          visible ? 'opacity-100' : 'opacity-0'
+        }`}
+        aria-hidden={!visible}
+      >
+        {content}
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -1,0 +1,18 @@
+export const HELP = {
+  battery: {
+    socMin: 'Niveau de réserve minimal : on arrête la décharge en dessous.',
+    socMax: 'Niveau maximal : on arrête la charge au-delà.'
+  },
+  ecs: {
+    target: 'Température d’eau souhaitée.',
+    pRes: 'Puissance de la résistance électrique (kW).'
+  },
+  kpi: {
+    selfConsumption: 'Part du PV consommée directement sur place.',
+    selfProduction: 'Part des besoins couverts par le PV.',
+    cycles: 'Approximation du nombre de cycles de batterie.',
+    netCost: 'Coût d’import moins revenu exporté, en euros.'
+  }
+} as const;
+
+export type HelpConfig = typeof HELP;

--- a/src/ui/panels/AssetsPanel.tsx
+++ b/src/ui/panels/AssetsPanel.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { BatteryParams } from '../../devices/Battery';
 import { DHWTankParams } from '../../devices/DHWTank';
 import { formatTemperature } from '../utils/ui';
+import FieldLabel from '../components/FieldLabel';
+import { HELP } from '../help';
 
 interface AssetsPanelProps {
   battery: BatteryParams;
@@ -87,8 +89,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               onChange={(event) => updateBattery('socInit_kWh', Number(event.target.value))}
             />
           </label>
-          <label className="text-sm text-slate-600">
-            SOC min (kWh)
+          <FieldLabel label="SOC min (kWh)" help={HELP.battery.socMin}>
             <input
               type="number"
               min={0}
@@ -97,9 +98,8 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               value={battery.socMin_kWh}
               onChange={(event) => updateBattery('socMin_kWh', Number(event.target.value))}
             />
-          </label>
-          <label className="text-sm text-slate-600">
-            SOC max (kWh)
+          </FieldLabel>
+          <FieldLabel label="SOC max (kWh)" help={HELP.battery.socMax}>
             <input
               type="number"
               min={0}
@@ -108,7 +108,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               value={battery.socMax_kWh}
               onChange={(event) => updateBattery('socMax_kWh', Number(event.target.value))}
             />
-          </label>
+          </FieldLabel>
         </div>
       </div>
 
@@ -126,8 +126,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               onChange={(event) => updateDhw('volume_L', Number(event.target.value))}
             />
           </label>
-          <label className="text-sm text-slate-600">
-            Puissance résistance (kW)
+          <FieldLabel label="Puissance résistance (kW)" help={HELP.ecs.pRes}>
             <input
               type="number"
               min={1}
@@ -136,7 +135,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               value={dhw.resistivePower_kW}
               onChange={(event) => updateDhw('resistivePower_kW', Number(event.target.value))}
             />
-          </label>
+          </FieldLabel>
           <label className="text-sm text-slate-600">
             Rendement chauffage
             <input
@@ -172,8 +171,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               onChange={(event) => updateDhw('ambientTemp_C', Number(event.target.value))}
             />
           </label>
-          <label className="text-sm text-slate-600">
-            Température cible (°C)
+          <FieldLabel label="Température cible (°C)" help={HELP.ecs.target}>
             <input
               type="number"
               min={30}
@@ -183,7 +181,7 @@ const AssetsPanel: React.FC<AssetsPanelProps> = ({ battery, dhw, onBatteryChange
               value={dhw.targetTemp_C}
               onChange={(event) => updateDhw('targetTemp_C', Number(event.target.value))}
             />
-          </label>
+          </FieldLabel>
           <label className="text-sm text-slate-600">
             Température initiale (°C)
             <input


### PR DESCRIPTION
## Summary
- add reusable Tooltip, FieldLabel, and KpiItem components that provide accessible contextual help
- centralize KPI and device help copy in src/ui/help.ts
- wire tooltips into the KPI comparison table and key Battery/ECS form labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf19cbe1bc83228c8ff585bf590c91