### PR TITLE
Add configurable ECS service contract modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ UI : Comparateur A/B avec graphiques synchronisés + export CSV/JSON
 
 Comparaisons : Appoint réseau automatique garantissant un ballon ECS conforme dans chaque scénario
 
+### Service ECS — mode Forcer vs Pénaliser
+
+* **Forcer** : applique un appoint réseau automatique si la température visée n’est pas atteinte avant l’heure limite. Pas de
+  pénalité ajoutée au coût net.
+* **Pénaliser** : aucun appoint final n’est déclenché ; un déficit de température résiduel génère une pénalité financière
+  (par défaut 0,08 €/K) ajoutée au coût net.
+* **Désactivé** : ni secours réseau automatique, ni pénalité — utile pour analyser une stratégie « pure ».
+
+La cible et l’heure limite du contrat sont configurables depuis le panneau ECS afin d’aligner le contrat sur vos exigences de
+service.
+
 🗺️ Roadmap courte
 
 S1 : Core + Batterie + ECS + UI de base + tests

--- a/src/core/kpis.ts
+++ b/src/core/kpis.ts
@@ -26,6 +26,9 @@ export interface SimulationKPIsCore {
 export interface SimulationKPIs extends SimulationKPIsCore {
   ecs_rescue_used: boolean;
   ecs_rescue_kWh: number;
+  ecs_deficit_K: number;
+  ecs_penalty_EUR: number;
+  net_cost_with_penalties: number;
 }
 
 export interface EuroKPIs {
@@ -33,6 +36,7 @@ export interface EuroKPIs {
   revenue_export: number;
   net_cost: number;
   saved_vs_nopv: number;
+  net_cost_with_penalties: number;
 }
 
 const energyFromPowerSeries = (power_kW: readonly number[], dt_s: number): number => {
@@ -118,7 +122,7 @@ export function eurosFromFlows(
   exportPrices: readonly number[]
 ): EuroKPIs {
   if (flows.length === 0 || dt_s <= 0) {
-    return { cost_import: 0, revenue_export: 0, net_cost: 0, saved_vs_nopv: 0 };
+    return { cost_import: 0, revenue_export: 0, net_cost: 0, saved_vs_nopv: 0, net_cost_with_penalties: 0 };
   }
   const dt_h = dt_s / 3600;
   let cost_import = 0;
@@ -139,7 +143,13 @@ export function eurosFromFlows(
   }
   const net_cost = cost_import - revenue_export;
   const saved_vs_nopv = baseline_cost - net_cost;
-  return { cost_import, revenue_export, net_cost, saved_vs_nopv };
+  return {
+    cost_import,
+    revenue_export,
+    net_cost,
+    saved_vs_nopv,
+    net_cost_with_penalties: net_cost
+  };
 }
 
 export const summarizeFlows = (

--- a/src/data/ecs-service.ts
+++ b/src/data/ecs-service.ts
@@ -1,0 +1,15 @@
+export type EcsEnforcementMode = 'force' | 'penalize' | 'off';
+
+export type EcsServiceConfig = {
+  enforcementMode: EcsEnforcementMode;
+  deadlineHour: number;
+  target_C: number;
+  penalty_EUR_per_K?: number;
+};
+
+export const defaultEcsServiceConfig = (): EcsServiceConfig => ({
+  enforcementMode: 'force',
+  deadlineHour: 21,
+  target_C: 55,
+  penalty_EUR_per_K: 0.08
+});

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,8 @@ import type { DHWTankParams } from '../devices/DHWTank';
 import type { Tariffs } from '../data/types';
 import { getScenario, PresetId } from '../data/scenarios';
 import { cloneTariffs } from '../data/tariffs';
+import type { EcsServiceConfig } from '../data/ecs-service';
+import { defaultEcsServiceConfig } from '../data/ecs-service';
 
 const App: React.FC = () => {
   const initialScenario = getScenario(PresetId.EteEnsoleille);
@@ -23,6 +25,11 @@ const App: React.FC = () => {
   const [strategyA, setStrategyA] = useState<StrategySelection>({ id: 'ecs_first' });
   const [strategyB, setStrategyB] = useState<StrategySelection>({ id: 'battery_first' });
   const [tariffs, setTariffs] = useState<Tariffs>(cloneTariffs(initialScenario.tariffs));
+  const [ecsService, setEcsService] = useState<EcsServiceConfig>(() => {
+    const defaults = defaultEcsServiceConfig();
+    defaults.target_C = initialScenario.defaults.ecsConfig.targetTemp_C;
+    return defaults;
+  });
 
   useEffect(() => {
     const scenario = getScenario(scenarioId);
@@ -30,6 +37,11 @@ const App: React.FC = () => {
     setBatteryParams({ ...scenario.defaults.batteryConfig });
     setDhwParams({ ...scenario.defaults.ecsConfig });
     setTariffs(cloneTariffs(scenario.tariffs));
+    setEcsService(() => {
+      const defaults = defaultEcsServiceConfig();
+      defaults.target_C = scenario.defaults.ecsConfig.targetTemp_C;
+      return defaults;
+    });
   }, [scenarioId]);
 
   const handleStrategyChange = (label: 'A' | 'B', selection: StrategySelection) => {
@@ -55,7 +67,14 @@ const App: React.FC = () => {
             <TariffPanel tariffs={tariffs} onChange={setTariffs} />
           </div>
           <div className="lg:col-span-2">
-            <AssetsPanel battery={batteryParams} dhw={dhwParams} onBatteryChange={setBatteryParams} onDhwChange={setDhwParams} />
+            <AssetsPanel
+              battery={batteryParams}
+              dhw={dhwParams}
+              ecsService={ecsService}
+              onBatteryChange={setBatteryParams}
+              onDhwChange={setDhwParams}
+              onEcsServiceChange={setEcsService}
+            />
           </div>
           <div className="lg:col-span-3">
             <StrategyPanel strategyA={strategyA} strategyB={strategyB} onChange={handleStrategyChange} />
@@ -66,6 +85,7 @@ const App: React.FC = () => {
           dt_s={dt_s}
           battery={batteryParams}
           dhw={dhwParams}
+          ecsService={ecsService}
           tariffs={tariffs}
           strategyA={strategyA}
           strategyB={strategyB}

--- a/src/workers/sim.worker.ts
+++ b/src/workers/sim.worker.ts
@@ -6,6 +6,7 @@ import { getScenarioPreset, PresetId } from '../data/scenarios';
 import type { Tariffs } from '../data/types';
 import { resolvePrices } from '../data/tariffs';
 import { DeviceConfig, createDevice } from '../devices/registry';
+import type { EcsServiceConfig } from '../data/ecs-service';
 
 export interface StrategyConfig {
   id: StrategyId;
@@ -20,6 +21,7 @@ export interface WorkerRequest {
   strategyA: StrategyConfig;
   strategyB: StrategyConfig;
   tariffs: Tariffs;
+  ecsService: EcsServiceConfig;
 }
 
 export interface WorkerResponse {
@@ -42,7 +44,7 @@ const cloneConfig = (config: DeviceConfig): DeviceConfig => {
 const cloneDevices = (configs: DeviceConfig[]) => configs.map((config) => createDevice(cloneConfig(config)));
 
 const handleMessage = (event: MessageEvent<WorkerRequest>) => {
-  const { scenarioId, dt_s, devicesConfig, strategyA, strategyB, tariffs, runId } = event.data;
+  const { scenarioId, dt_s, devicesConfig, strategyA, strategyB, tariffs, runId, ecsService } = event.data;
   const preset = getScenarioPreset(scenarioId) ?? getScenarioPreset(PresetId.EteEnsoleille);
   if (!preset) {
     throw new Error('Aucun scénario valide trouvé.');
@@ -63,7 +65,8 @@ const handleMessage = (event: MessageEvent<WorkerRequest>) => {
       strategy,
       ambientTemp_C: 20,
       importPrices_EUR_per_kWh: importPrices,
-      exportPrices_EUR_per_kWh: exportPrices
+      exportPrices_EUR_per_kWh: exportPrices,
+      ecsService
     });
   };
 

--- a/tests/ecs_service_contract.test.ts
+++ b/tests/ecs_service_contract.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getScenario, PresetId } from '../src/data/scenarios';
+import { DHWTank } from '../src/devices/DHWTank';
+import { runSimulation } from '../src/core/engine';
+import { defaultEcsServiceConfig } from '../src/data/ecs-service';
+
+type EnforcementMode = 'force' | 'penalize' | 'off';
+
+const runWithMode = (mode: EnforcementMode) => {
+  const scenario = getScenario(PresetId.HiverCouvert);
+  const tank = new DHWTank('dhw', 'Ballon ECS', { ...scenario.defaults.ecsConfig });
+  const ecsService = { ...defaultEcsServiceConfig(), enforcementMode: mode, target_C: tank.targetTemp };
+  const result = runSimulation({
+    dt_s: scenario.dt,
+    pvSeries_kW: scenario.pv,
+    baseLoadSeries_kW: scenario.load_base,
+    devices: [tank],
+    strategy: () => [],
+    ecsService
+  });
+  return { result, tank, ecsService };
+};
+
+describe('Contrat ECS', () => {
+  it('force le secours réseau si nécessaire', () => {
+    const { result, tank, ecsService } = runWithMode('force');
+
+    expect(result.kpis.ecs_rescue_used).toBe(true);
+    expect(result.kpis.ecs_rescue_kWh).toBeGreaterThan(0);
+    expect(result.totals.ecsRescue_kWh).toBeCloseTo(result.kpis.ecs_rescue_kWh, 6);
+    expect(result.kpis.ecs_penalty_EUR).toBe(0);
+    expect(result.totals.ecsPenalty_EUR).toBe(0);
+    expect(result.kpis.net_cost_with_penalties).toBeCloseTo(result.kpis.euros.net_cost, 6);
+    expect(result.kpis.euros.net_cost_with_penalties).toBeCloseTo(result.kpis.net_cost_with_penalties, 6);
+    expect(result.kpis.ecs_deficit_K).toBe(0);
+    expect(tank.temperature).toBeGreaterThanOrEqual(ecsService.target_C - 1e-6);
+  });
+
+  it('applique une pénalité lorsque le service est en mode pénalisation', () => {
+    const { result, tank, ecsService } = runWithMode('penalize');
+
+    expect(result.kpis.ecs_rescue_used).toBe(false);
+    expect(result.kpis.ecs_rescue_kWh).toBe(0);
+    expect(result.totals.ecsRescue_kWh).toBe(0);
+    expect(result.kpis.ecs_deficit_K).toBeGreaterThan(0);
+    expect(result.totals.ecsDeficit_K).toBeCloseTo(result.kpis.ecs_deficit_K, 6);
+    expect(result.kpis.ecs_penalty_EUR).toBeGreaterThan(0);
+    expect(result.totals.ecsPenalty_EUR).toBeCloseTo(result.kpis.ecs_penalty_EUR, 6);
+    expect(result.kpis.net_cost_with_penalties).toBeCloseTo(
+      result.kpis.euros.net_cost + result.kpis.ecs_penalty_EUR,
+      6
+    );
+    expect(result.kpis.euros.net_cost_with_penalties).toBeCloseTo(result.kpis.net_cost_with_penalties, 6);
+    expect(tank.temperature).toBeLessThan(ecsService.target_C);
+  });
+
+  it('désactive appoint et pénalités en mode off', () => {
+    const { result, tank, ecsService } = runWithMode('off');
+
+    expect(result.kpis.ecs_rescue_used).toBe(false);
+    expect(result.kpis.ecs_rescue_kWh).toBe(0);
+    expect(result.totals.ecsRescue_kWh).toBe(0);
+    expect(result.kpis.ecs_penalty_EUR).toBe(0);
+    expect(result.totals.ecsPenalty_EUR).toBe(0);
+    expect(result.kpis.net_cost_with_penalties).toBeCloseTo(result.kpis.euros.net_cost, 6);
+    expect(result.kpis.euros.net_cost_with_penalties).toBeCloseTo(result.kpis.net_cost_with_penalties, 6);
+    expect(tank.temperature).toBeLessThan(ecsService.target_C);
+  });
+});


### PR DESCRIPTION
## Summary
- add an ECS service contract configuration with optional penalties to the simulation engine
- expose the new metrics in the UI with editable contract parameters and comparison badges
- cover the behaviour with dedicated Vitest scenarios and document the service modes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfcc4d81e08322918458c9a980bbbc