### PR TITLE
Update backlog for ECS contract completion

### DIFF
--- a/Docs/todo.md
+++ b/Docs/todo.md
@@ -1,25 +1,26 @@
 # EnerFlux — Backlog / TODO (2025-09-20)
 
 ## Court terme (S3)
-- [ ] Implémenter **contrat de service ECS** :
-  - [ ] Types & transport (`EcsServiceContract`)
-  - [ ] KPI service : T° @deadline, déficit K, pénalités €, net_cost_with_penalties
-  - [ ] Badge “Service ECS” dans UI + affichage pénalités
-- [ ] Stratégies optionnelles :
-  - [ ] `ecs_hysteresis`
-  - [ ] `deadline_helper`
-- [ ] Tests Vitest :
-  - [ ] Vérifier pénalité si T° < cible à la deadline
-  - [ ] Vérifier `deadline_helper` respecte contrainte
-- [ ] Docs :
-  - [ ] README : section “Contrat de service ECS”
+- [x] Implémenter **contrat de service ECS** :
+  - [x] Types & transport (`EcsServiceContract`)
+  - [x] KPI service : T° @deadline, déficit K, pénalités €, net_cost_with_penalties
+  - [x] Badge/UI pour visualiser secours ou pénalités
+- [x] Tests Vitest :
+  - [x] Vérifier pénalité si T° < cible à la deadline (`ecs_service_contract.test.ts`)
+  - [x] Vérifier comportements helpers/hystérésis (`ecs_helpers.test.ts`)
+- [x] Docs :
+  - [x] README : section “Contrat de service ECS”
+- [ ] Exposer les stratégies **`ecs_hysteresis`** et **`deadline_helper`** dans `core/strategy.ts`
+  - [ ] Ajouter sélection correspondante dans la UI (panel Stratégie + worker)
+  - [ ] Décrire l’impact dans l’aide (tooltip HELP)
+- [ ] Ajouter presets S3 autour des contrats ECS (ex : « Matin froid », « Ballon confort »)
 
 ## Moyen terme (S4)
 - [ ] Étendre KPIs économiques :
   - [ ] ROI simplifié (temps de retour sur investissement)
   - [ ] Δ € vs scénario “grid-only”
-- [ ] Ajouter presets “TOU MatinFroid”, “TOU BatterieVide” (déjà esquissés)
 - [ ] Ajouter stratégie `reserve_evening`
+- [ ] UI : vue condensée des KPIs + comparaison multi-métriques
 
 ## Long terme
 - [ ] Intégrer chauffage, piscine, VE


### PR DESCRIPTION
## Summary
- mark the ECS service contract, tests, and docs tasks as delivered in the backlog
- add upcoming items for exposing new ECS helpers and presets in the short-term roadmap

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e048a2a9988322bf097d957ef27c4d