### PR TITLE
Expose ECS helper strategies in UI

### DIFF
--- a/Docs/todo.md
+++ b/Docs/todo.md
@@ -1,25 +1,26 @@
 # EnerFlux — Backlog / TODO (2025-09-20)
 
 ## Court terme (S3)
-- [ ] Implémenter **contrat de service ECS** :
-  - [ ] Types & transport (`EcsServiceContract`)
-  - [ ] KPI service : T° @deadline, déficit K, pénalités €, net_cost_with_penalties
-  - [ ] Badge “Service ECS” dans UI + affichage pénalités
-- [ ] Stratégies optionnelles :
-  - [ ] `ecs_hysteresis`
-  - [ ] `deadline_helper`
-- [ ] Tests Vitest :
-  - [ ] Vérifier pénalité si T° < cible à la deadline
-  - [ ] Vérifier `deadline_helper` respecte contrainte
-- [ ] Docs :
-  - [ ] README : section “Contrat de service ECS”
+- [x] Implémenter **contrat de service ECS** :
+  - [x] Types & transport (`EcsServiceContract`)
+  - [x] KPI service : T° @deadline, déficit K, pénalités €, net_cost_with_penalties
+  - [x] Badge/UI pour visualiser secours ou pénalités
+- [x] Tests Vitest :
+  - [x] Vérifier pénalité si T° < cible à la deadline (`ecs_service_contract.test.ts`)
+  - [x] Vérifier comportements helpers/hystérésis (`ecs_helpers.test.ts`)
+- [x] Docs :
+  - [x] README : section “Contrat de service ECS”
+- [x] Exposer les stratégies **`ecs_hysteresis`** et **`deadline_helper`** dans `core/strategy.ts`
+  - [x] Ajouter sélection correspondante dans la UI (panel Stratégie + worker)
+  - [x] Décrire l’impact dans l’aide (tooltip HELP)
+- [ ] Ajouter presets S3 autour des contrats ECS (ex : « Matin froid », « Ballon confort »)
 
 ## Moyen terme (S4)
 - [ ] Étendre KPIs économiques :
   - [ ] ROI simplifié (temps de retour sur investissement)
   - [ ] Δ € vs scénario “grid-only”
-- [ ] Ajouter presets “TOU MatinFroid”, “TOU BatterieVide” (déjà esquissés)
 - [ ] Ajouter stratégie `reserve_evening`
+- [ ] UI : vue condensée des KPIs + comparaison multi-métriques
 
 ## Long terme
 - [ ] Intégrer chauffage, piscine, VE

--- a/src/core/strategy.ts
+++ b/src/core/strategy.ts
@@ -1,6 +1,11 @@
 import { Device, PowerRequest } from '../devices/Device';
 
-export type StrategyId = 'ecs_first' | 'battery_first' | 'mix_soc_threshold';
+export type StrategyId =
+  | 'ecs_first'
+  | 'ecs_hysteresis'
+  | 'deadline_helper'
+  | 'battery_first'
+  | 'mix_soc_threshold';
 
 export interface StrategyRequest {
   device: Device;
@@ -74,6 +79,10 @@ const isElectricalStorage = (req: StrategyRequest): boolean =>
 export const ecsFirstStrategy: Strategy = (context) =>
   allocateFollowingOrder(context, (req) => (isThermal(req) ? 0 : 1));
 
+export const ecsHysteresisStrategy: Strategy = (context) => ecsFirstStrategy(context);
+
+export const ecsDeadlineHelperStrategy: Strategy = (context) => ecsFirstStrategy(context);
+
 export const batteryFirstStrategy: Strategy = (context) =>
   allocateFollowingOrder(context, (req) => (isElectricalStorage(req) ? 0 : 1));
 
@@ -107,6 +116,10 @@ export const resolveStrategy = (
   switch (id) {
     case 'ecs_first':
       return ecsFirstStrategy;
+    case 'ecs_hysteresis':
+      return ecsHysteresisStrategy;
+    case 'deadline_helper':
+      return ecsDeadlineHelperStrategy;
     case 'battery_first':
       return batteryFirstStrategy;
     case 'mix_soc_threshold':

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
   const [dhwParams, setDhwParams] = useState<DHWTankParams>({
     ...initialScenario.defaults.ecsConfig
   });
-  const [strategyA, setStrategyA] = useState<StrategySelection>({ id: 'ecs_first' });
+  const [strategyA, setStrategyA] = useState<StrategySelection>({ id: 'ecs_hysteresis' });
   const [strategyB, setStrategyB] = useState<StrategySelection>({ id: 'battery_first' });
   const [tariffs, setTariffs] = useState<Tariffs>(cloneTariffs(initialScenario.tariffs));
   const [ecsService, setEcsService] = useState<EcsServiceContract>(() => {

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -12,6 +12,15 @@ export const HELP = {
     selfProduction: 'Part des besoins couverts par le PV.',
     cycles: 'Approximation du nombre de cycles de batterie.',
     netCost: 'Coût d’import moins revenu exporté, en euros.'
+  },
+  strategy: {
+    ecsFirst: 'Priorité ECS pure : aucun helper, utile comme scénario de référence.',
+    ecsHysteresis:
+      'Active l’hystérésis ECS pour lisser les déclenchements : on recharge seulement après avoir suffisamment refroidi.',
+    deadlineHelper:
+      'Combine hystérésis et préchauffe anticipée dans la dernière fenêtre avant la deadline afin de limiter secours ou pénalités.',
+    batteryFirst: 'Recharge d’abord la batterie ; l’ECS passe ensuite ou en cas d’urgence (deadline).',
+    mixSoc: 'Bascule batterie→ECS selon un seuil de SOC ajustable.'
   }
 } as const;
 

--- a/src/ui/panels/StrategyPanel.tsx
+++ b/src/ui/panels/StrategyPanel.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { StrategyId } from '../../core/strategy';
+import Tooltip from '../components/Tooltip';
+import { HELP } from '../help';
 
 export interface StrategySelection {
   id: StrategyId;
@@ -12,13 +14,39 @@ interface StrategyPanelProps {
   onChange: (label: 'A' | 'B', selection: StrategySelection) => void;
 }
 
-const strategies: { id: StrategyId; label: string; description: string }[] = [
-  { id: 'ecs_first', label: 'ECS prioritaire', description: 'Dirige le surplus vers l’ECS avant la batterie.' },
-  { id: 'battery_first', label: 'Batterie prioritaire', description: 'Recharge la batterie avant de chauffer l’ECS.' },
+const infoIconClasses =
+  'ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full bg-slate-700/20 text-[10px] font-semibold text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400';
+
+const strategies: { id: StrategyId; label: string; description: string; help?: string }[] = [
+  {
+    id: 'ecs_first',
+    label: 'ECS prioritaire (brut)',
+    description: 'Priorité ECS sans helpers automatiques.',
+    help: HELP.strategy.ecsFirst
+  },
+  {
+    id: 'ecs_hysteresis',
+    label: 'ECS + hystérésis',
+    description: 'Laisse refroidir avant de relancer pour limiter les yo-yo.',
+    help: HELP.strategy.ecsHysteresis
+  },
+  {
+    id: 'deadline_helper',
+    label: 'ECS + préchauffe deadline',
+    description: 'Active hystérésis et préchauffe avant l’heure cible.',
+    help: HELP.strategy.deadlineHelper
+  },
+  {
+    id: 'battery_first',
+    label: 'Batterie prioritaire',
+    description: 'Recharge la batterie avant de chauffer l’ECS.',
+    help: HELP.strategy.batteryFirst
+  },
   {
     id: 'mix_soc_threshold',
     label: 'Mix (seuil SOC)',
-    description: 'Aiguillage dynamique en fonction du niveau de charge.'
+    description: 'Aiguillage dynamique en fonction du niveau de charge.',
+    help: HELP.strategy.mixSoc
   }
 ];
 
@@ -39,9 +67,24 @@ const StrategyPanel: React.FC<StrategyPanelProps> = ({ strategyA, strategyB, onC
           ))}
         </select>
       </div>
-      <p className="text-xs text-slate-500">
-        {strategies.find((strategy) => strategy.id === selection.id)?.description}
-      </p>
+      {(() => {
+        const strategy = strategies.find((item) => item.id === selection.id);
+        if (!strategy) {
+          return null;
+        }
+        return (
+          <p className="flex items-center text-xs text-slate-500">
+            <span>{strategy.description}</span>
+            {strategy.help ? (
+              <Tooltip content={strategy.help}>
+                <span tabIndex={0} aria-label="Informations" className={infoIconClasses}>
+                  ⓘ
+                </span>
+              </Tooltip>
+            ) : null}
+          </p>
+        );
+      })()}
       {selection.id === 'mix_soc_threshold' ? (
         <label className="text-sm text-slate-600">
           Seuil SOC (%)

--- a/src/workers/sim.worker.ts
+++ b/src/workers/sim.worker.ts
@@ -7,6 +7,7 @@ import type { Tariffs } from '../data/types';
 import { resolvePrices } from '../data/tariffs';
 import { DeviceConfig, createDevice } from '../devices/registry';
 import type { EcsServiceContract } from '../data/ecs-service';
+import { resolveEcsServiceForStrategy } from './strategy-contract';
 
 export interface StrategyConfig {
   id: StrategyId;
@@ -57,6 +58,7 @@ const handleMessage = (event: MessageEvent<WorkerRequest>) => {
     const strategy = resolveStrategy(strategyConfig.id, {
       thresholdPercent: strategyConfig.thresholdPercent
     });
+    const ecsContract = resolveEcsServiceForStrategy(ecsService, strategyConfig.id);
     return runSimulation({
       dt_s: series.dt_s,
       pvSeries_kW: series.pvSeries_kW,
@@ -66,7 +68,7 @@ const handleMessage = (event: MessageEvent<WorkerRequest>) => {
       ambientTemp_C: 20,
       importPrices_EUR_per_kWh: importPrices,
       exportPrices_EUR_per_kWh: exportPrices,
-      ecsService
+      ecsService: ecsContract
     });
   };
 

--- a/src/workers/strategy-contract.ts
+++ b/src/workers/strategy-contract.ts
@@ -1,0 +1,27 @@
+import type { EcsServiceContract } from '../data/ecs-service';
+import { cloneEcsServiceContract } from '../data/ecs-service';
+import type { StrategyId } from '../core/strategy';
+
+export const resolveEcsServiceForStrategy = (
+  base: EcsServiceContract,
+  strategyId: StrategyId
+): EcsServiceContract => {
+  const contract = cloneEcsServiceContract(base);
+  switch (strategyId) {
+    case 'ecs_first':
+      contract.helpers.hysteresisEnabled = false;
+      contract.helpers.deadlineEnabled = false;
+      break;
+    case 'ecs_hysteresis':
+      contract.helpers.hysteresisEnabled = true;
+      contract.helpers.deadlineEnabled = false;
+      break;
+    case 'deadline_helper':
+      contract.helpers.hysteresisEnabled = true;
+      contract.helpers.deadlineEnabled = true;
+      break;
+    default:
+      break;
+  }
+  return contract;
+};

--- a/tests/strategy_registry.test.ts
+++ b/tests/strategy_registry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveStrategy,
+  ecsFirstStrategy,
+  type Strategy,
+  type StrategyContext,
+  type StrategyRequest
+} from '../src/core/strategy';
+import type { Device } from '../src/devices/Device';
+import { defaultEcsServiceContract } from '../src/data/ecs-service';
+import { resolveEcsServiceForStrategy } from '../src/workers/strategy-contract';
+
+const createDevice = (id: string, capabilities: Device['capabilities'][number][]): Device => ({
+  id,
+  label: id,
+  capabilities,
+  plan: () => ({}),
+  apply: () => {},
+  state: () => ({})
+});
+
+const createContext = (): StrategyContext => {
+  const ecsDevice = createDevice('ecs', ['thermal-storage']);
+  const batteryDevice = createDevice('battery', ['electrical-storage']);
+  const requests: StrategyRequest[] = [
+    {
+      device: ecsDevice,
+      request: { maxAccept_kW: 3, need: 'toHeat' },
+      state: {}
+    },
+    {
+      device: batteryDevice,
+      request: { maxAccept_kW: 4, need: 'toStore' },
+      state: {}
+    }
+  ];
+  return {
+    surplus_kW: 5,
+    requests
+  };
+};
+
+const getFirstAllocationDevice = (strategy: Strategy, context: StrategyContext): string | undefined => {
+  const allocations = strategy(context);
+  return allocations[0]?.deviceId;
+};
+
+describe('strategy registry', () => {
+  it('maps ecs_hysteresis to ecs_first ordering logic', () => {
+    const context = createContext();
+    const reference = getFirstAllocationDevice(ecsFirstStrategy, context);
+    const resolved = getFirstAllocationDevice(resolveStrategy('ecs_hysteresis'), context);
+    expect(resolved).toBe(reference);
+  });
+
+  it('maps deadline_helper to ecs_first ordering logic', () => {
+    const context = createContext();
+    const reference = getFirstAllocationDevice(ecsFirstStrategy, context);
+    const resolved = getFirstAllocationDevice(resolveStrategy('deadline_helper'), context);
+    expect(resolved).toBe(reference);
+  });
+
+  it('derives ECS service helpers per strategy without mutating base contract', () => {
+    const base = defaultEcsServiceContract();
+    base.helpers.hysteresisEnabled = false;
+    base.helpers.deadlineEnabled = false;
+
+    const ecsFirstContract = resolveEcsServiceForStrategy(base, 'ecs_first');
+    const hysteresisContract = resolveEcsServiceForStrategy(base, 'ecs_hysteresis');
+    const deadlineContract = resolveEcsServiceForStrategy(base, 'deadline_helper');
+
+    expect(base.helpers.hysteresisEnabled).toBe(false);
+    expect(base.helpers.deadlineEnabled).toBe(false);
+
+    expect(ecsFirstContract.helpers.hysteresisEnabled).toBe(false);
+    expect(ecsFirstContract.helpers.deadlineEnabled).toBe(false);
+
+    expect(hysteresisContract.helpers.hysteresisEnabled).toBe(true);
+    expect(hysteresisContract.helpers.deadlineEnabled).toBe(false);
+
+    expect(deadlineContract.helpers.hysteresisEnabled).toBe(true);
+    expect(deadlineContract.helpers.deadlineEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add ECS helper strategy identifiers and map them to service-contract helper toggles in the worker
- expose the new ECS helper options in the strategy panel with contextual help and default selections
- cover the helper mapping with unit tests and mark the backlog item as delivered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e048a2a9988322bf097d957ef27c4d